### PR TITLE
fix(emacs): do not create temp buffer on non-matching completion

### DIFF
--- a/.emacs.d/inits/29_helm.el
+++ b/.emacs.d/inits/29_helm.el
@@ -38,4 +38,9 @@
 
 (helm-autoresize-mode 1)
 
+(defadvice helm-ff-kill-or-find-buffer-fname (around execute-only-if-exist activate)
+  "Execute command only if CANDIDATE exists"
+  (when (file-exists-p candidate)
+    ad-do-it))
+
 (helm-mode 1)


### PR DESCRIPTION
helmで補完を行うとき、存在しないファイルやフォルダー名を入力した状態でTABを押すとその名前のバッファーができてしまうのを防ぐ設定(参考: https://abicky.net/2014/01/04/170448/)

Signed-off-by: soblin <hilo.soblin@gmail.com>
