### PR TITLE
fix(ansible): fix fish .config/fish initializatin

### DIFF
--- a/ansible/roles/dev_tools/tasks/commands/fish.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/fish.yaml
@@ -28,7 +28,7 @@
         src: "{{ (playbook_dir + '/../.config/fish') | realpath }}"
         dest: "{{ lookup('env', 'HOME') }}/.config/fish"
         state: link
-      when: not fish_config_exists.stat.exists
+      when: not fish_config_exists.stat.islnk
 
     # TODO: tmux-mem-cpu-load
     - name: install plugins from fish_plugins file

--- a/ansible/roles/dev_tools/tasks/commands/fish.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/fish.yaml
@@ -28,7 +28,7 @@
         src: "{{ (playbook_dir + '/../.config/fish') | realpath }}"
         dest: "{{ lookup('env', 'HOME') }}/.config/fish"
         state: link
-      when: not fish_config_exists.stat.islnk
+      when: (not fish_config_exists.stat.exists) or (not fish_config_exists.stat.islnk)
 
     # TODO: tmux-mem-cpu-load
     - name: install plugins from fish_plugins file

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# /home/<user>
+home_dir=`realpath ~`
+
 cur_dir=`pwd`
 
 function create_symlink_f() {


### PR DESCRIPTION
fishをinstallすると `.config/fish` が作られるので、symlinkの生成が[fish_config_exists.stat.exists](https://github.com/soblin/dotfiles/blob/a04e3a7ff983c7115f55f3b640f1e4aa6bc1d835/ansible/roles/dev_tools/tasks/commands/fish.yaml#L31)だとskipされてしまう。`.config/fish`がない場合もあるのでci用に改善が必要