### PR TITLE
feat(ansbile): snap refresh on baremetal

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -3,6 +3,7 @@
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ lookup('env','HOME') }}/.local/bin"
   roles:
+    - init_snap
     - xdg_base_directory
     - system_tools
     - dev_tools

--- a/ansible/roles/init_snap/defaults/main.yaml
+++ b/ansible/roles/init_snap/defaults/main.yaml
@@ -1,0 +1,2 @@
+# on ci, snapd does not exist, so `snap refresh` may fail
+is_ci: false

--- a/ansible/roles/init_snap/tasks/main.yaml
+++ b/ansible/roles/init_snap/tasks/main.yaml
@@ -1,0 +1,5 @@
+- name: refresh snap
+  become: true
+  command: snap refresh
+  when: not is_ci
+  changed_when: false


### PR DESCRIPTION
実機ではrefreshしないと `sudo snap install emacs --classic` が失敗する