### PR TITLE
feat(peco): use tmup popup

### DIFF
--- a/.config/fish/configs/peco_anything.fish
+++ b/.config/fish/configs/peco_anything.fish
@@ -1,4 +1,45 @@
-set -l peco_anything_prompt "  peco completion "
+function set_bold
+    set -l text $argv[1]
+    printf "%b%s%b" (tput bold) "$text" (tput sgr0)
+end
+
+function set_fg
+    printf "\e[38;5;%sm" $argv[1]
+end
+
+function set_bg
+    printf "\e[48;5;%sm" $argv[1]
+end
+
+function set_reset
+    printf "\e[0m"
+end
+
+function create_color_string
+    set -l fg $argv[1] # 256 color
+    set -l bg $argv[2] # 256 color
+    set -l text $argv[3..-1]
+
+    printf "%b%b%s%b" (set_fg $fg)(set_bg $bg) "$text" (set_reset)
+end
+
+set -g peco_anything_prompt "  peco completion "
+
+function create_dracula_prompt
+    set -l prompt (set_bold (string join "" $argv[1] " "))
+    set -l gray_blue 60
+    set -l dark_gray_blue 238
+    set -l pink_violet 141
+    set -l pink 212
+    set -l black 237
+    set -l peco_anything_prompt_bold (set_bold $peco_anything_prompt)
+    set -l separator " "
+
+    printf "%b%b%b%b%s%b" (create_color_string $dark_gray_blue $gray_blue $peco_anything_prompt_bold ) \
+        (create_color_string $gray_blue $pink_violet $separator ) \
+        (create_color_string $black $pink_violet $prompt) \
+        (set_fg $pink_violet) "$separator" (set_reset)
+end
 
 function peco_complete_cmd_anything
     set -l tokens (commandline --tokenize)
@@ -12,6 +53,7 @@ function peco_complete_cmd_anything
         switch "$token"
             case git
                 peco_git_dispatch $tokens[$i..$len]
+                # docker, etc.
             case '*'
                 return
         end

--- a/.config/fish/configs/peco_anything.fish
+++ b/.config/fish/configs/peco_anything.fish
@@ -1,45 +1,4 @@
-function set_bold
-    set -l text $argv[1]
-    printf "%b%s%b" (tput bold) "$text" (tput sgr0)
-end
-
-function set_fg
-    printf "\e[38;5;%sm" $argv[1]
-end
-
-function set_bg
-    printf "\e[48;5;%sm" $argv[1]
-end
-
-function set_reset
-    printf "\e[0m"
-end
-
-function create_color_string
-    set -l fg $argv[1] # 256 color
-    set -l bg $argv[2] # 256 color
-    set -l text $argv[3..-1]
-
-    printf "%b%b%s%b" (set_fg $fg)(set_bg $bg) "$text" (set_reset)
-end
-
-set -g peco_anything_prompt "  peco completion "
-
-function create_dracula_prompt
-    set -l prompt (set_bold (string join "" $argv[1] " "))
-    set -l gray_blue 60
-    set -l dark_gray_blue 238
-    set -l pink_violet 141
-    set -l pink 212
-    set -l black 237
-    set -l peco_anything_prompt_bold (set_bold $peco_anything_prompt)
-    set -l separator " "
-
-    printf "%b%b%b%b%s%b" (create_color_string $dark_gray_blue $gray_blue $peco_anything_prompt_bold ) \
-        (create_color_string $gray_blue $pink_violet $separator ) \
-        (create_color_string $black $pink_violet $prompt) \
-        (set_fg $pink_violet) "$separator" (set_reset)
-end
+set -l peco_anything_prompt "  peco completion "
 
 function peco_complete_cmd_anything
     set -l tokens (commandline --tokenize)
@@ -53,7 +12,6 @@ function peco_complete_cmd_anything
         switch "$token"
             case git
                 peco_git_dispatch $tokens[$i..$len]
-                # docker, etc.
             case '*'
                 return
         end

--- a/.config/rcs/peco_anything_helper.sh
+++ b/.config/rcs/peco_anything_helper.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set_bold() {
+    local text="$1"
+    printf "%b%s%b" "$(tput bold)" "$text" "$(tput sgr0)"
+}
+
+set_fg() {
+    local color="$1"
+    printf "\e[38;5;%sm" "$color"
+}
+
+set_bg() {
+    local color="$1"
+    printf "\e[48;5;%sm" "$color"
+}
+
+set_reset() {
+    printf "\e[0m"
+}
+
+create_color_string() {
+    local fg="$1"
+    local bg="$2"
+    shift 2
+    local text="$*"
+
+    printf "%b%b%s%b" \
+        "$(set_fg "$fg")" \
+        "$(set_bg "$bg")" \
+        "$text" \
+        "$(set_reset)"
+}
+
+peco_anything_prompt="  peco completion "
+
+create_dracula_prompt() {
+    local prompt
+    prompt="$(set_bold "$1 ")"
+
+    local gray_blue=60
+    local dark_gray_blue=238
+    local pink_violet=141
+    local pink=212
+    local black=237
+
+    local peco_anything_prompt_bold
+    peco_anything_prompt_bold="$(set_bold "$peco_anything_prompt")"
+
+    local separator=" "
+
+    printf "%b%b%b%b%s%b" \
+        "$(create_color_string "$black" "$pink_violet" "$peco_anything_prompt_bold")" \
+        "$(create_color_string "$pink_violet" "$pink" "$separator")" \
+        "$(create_color_string "$dark_gray_blue" "$pink" "$prompt")" \
+        "$(set_fg "$pink")" \
+        "$separator" \
+        "$(set_reset)"
+}

--- a/ansible/roles/system_tools/tasks/commands/tmux.yaml
+++ b/ansible/roles/system_tools/tasks/commands/tmux.yaml
@@ -1,7 +1,8 @@
 # tmux
 - name: setup tmux
   block:
-    - name: apt install tmux
+    - name: snap install tmux
+      # NOTE: apt version is old(3.2a)
       apt:
         name: tmux
         state: present


### PR DESCRIPTION
# stage1

<img width="858" height="75" alt="image" src="https://github.com/user-attachments/assets/c38bded4-70a7-4bdc-872d-6f379957ff4e" />

## stage2

pecoのpromtに表示させるのは無理。
tmuxのpopupのstatus lineに表示させる路線で行く

こういうpluginがある
https://github.com/loichyan/tmux-toggle-popup

`display-popup -T`でフォーマットを指定できる？ `snap`でtmuxを入れるとこのフラグを使える．ただ補完などが効かない（`/usr/share/fish/completions/tmutil.fish`の内容が合っていないため．）

```bash
tmux display-popup -E -T "status line here" -d (pwd) "git ls-files . | peco --prompt \"prompt\" "
```

- [ ] snapでtmuxを入れる
- [ ] completionをそれに揃える

## stage3

```bash
tmux display-popup -E -T "\e[38;5;141m status line here \e[0m" -d (pwd) "git ls-files . | peco --prompt \"prompt\" "
```

してもstatus lineに色は付かない．なので単一色を以下で付けるしかなさそう

https://man7.org/linux/man-pages/man1/tmux.1.html#STYLES

## success

```bash
tmux display-popup -E -T "#[fg=color237, bg=color141]  peco completion #[fg=color141, bg=color212]#[fg=color60, bg=color212]  git branches  #[fg=color212, bg=default]" -d (pwd) "git ls-files . | peco --prompt \"prompt\" "
```

<img width="956" height="461" alt="image" src="https://github.com/user-attachments/assets/a8ec84c9-36c2-4468-b214-29a6df433944" />
