### PR TITLE
feat(looks): opaque theme

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -3,11 +3,14 @@ local config = wezterm.config_builder()
 
 config.automatically_reload_config = true
 config.scrollback_lines = 10000
--- config.window_background_opacity = 0.5
+
+config.window_background_opacity = 0.85
+-- config.kde_window_background_blur = true
 
 -- theme
 config.color_scheme = 'Dracula (Official)'
 
+--[[
 config.background = {
    {
       source = {
@@ -16,11 +19,20 @@ config.background = {
       hsb = { brightness = 0.075 },
    }
 }
+--]]
 
 -- font
 config.font = wezterm.font {
    family = 'HackGen Console NF',
 }
 config.font_size = 12
+
+-- title bar
+config.window_decorations = "RESIZE"
+-- config.hide_tab_bar_if_only_one_tab = true
+config.window_frame = {
+   inactive_titlebar_bg = "none",
+   active_titlebar_bg = "none",
+}
 
 return config

--- a/.emacs.d/inits/02_theme.el
+++ b/.emacs.d/inits/02_theme.el
@@ -43,6 +43,18 @@
 
 (tab-bar-mode 1)
 
+;; -nwオプションで動作していたら背景をterminalに合わせる
+(defun on-after-init ()
+  (unless (display-graphic-p (selected-frame))
+    (set-face-background 'default "unspecified-bg" (selected-frame))))
+(add-hook 'window-setup-hook #'on-after-init)
+
+(defun on-frame-open (&optional frame)
+  "If the FRAME created in terminal don't load background color."
+  (unless (display-graphic-p frame)
+    (set-face-background 'default "unspecified-bg" frame)))
+(add-hook 'after-make-frame-functions #'on-frame-open)
+
 ;;; End:
 
 ;;; 02_doom ends here

--- a/cspell.json
+++ b/cspell.json
@@ -125,6 +125,7 @@
 
         "peco",
 
-        "wezterm"
+        "wezterm",
+        "titlebar"
     ]
 }


### PR DESCRIPTION
# wezterm

https://zenn.dev/mozumasu/articles/mozumasu-wezterm-customization

# Emacs

https://www.reddit.com/r/emacs/comments/1d9d1ob/getting_emacs_terminal_transparent/
https://stackoverflow.com/questions/19054228/emacs-disable-theme-background-color-in-terminal/20233611#20233611
を参考に
