### PR TITLE
feat(emacs): enhance lsp ui for nw

### DIFF
--- a/.emacs.d/lisp/06_lsp.el
+++ b/.emacs.d/lisp/06_lsp.el
@@ -23,6 +23,8 @@
 (use-package lsp-ui
   :config
   (setq lsp-ui-peek-enable t)
+  (setq lsp-ui-doc-show-with-mouse nil)
+  (setq lsp-ui-doc-show-with-cursor t)
   )
 
 (use-package flycheck
@@ -125,6 +127,12 @@
   (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)
   )
 
+
+(use-package corfu-terminal
+  :init
+  :config
+  (unless (display-graphic-p) (corfu-terminal-mode t))
+  )
 
 (provide '06_lsp)
 ;;; 06_lsp.el ends here


### PR DESCRIPTION
# Corfu terminal

show candidates in corfu popup even in `nw` mode
<img width="1867" height="701" alt="image" src="https://github.com/user-attachments/assets/5c03b722-3d1a-4671-bc73-812cda58fe11" />

<img width="918" height="521" alt="image" src="https://github.com/user-attachments/assets/e7e583a0-a118-4866-9e0d-c86f01966c0b" />
