### PR TITLE
feat(emacs): improve key response for flycheck

### DIFF
--- a/.emacs.d/lisp/06_lsp.el
+++ b/.emacs.d/lisp/06_lsp.el
@@ -35,6 +35,10 @@
 (use-package flycheck
   :ensure t
   :init (global-flycheck-mode)
+
+  :config
+  ;; (setq flycheck-check-syntax-automatically '(save new-line mode-enabled))
+  (setq flycheck-idle-change-delay 2.25)
   )
 
 


### PR DESCRIPTION
flycheckのせいでタイピング中に遅れが生じるため

https://github.com/emacs-lsp/lsp-mode/issues/3612