### PR TITLE
feat(ansible): install rust toolchain via rustup

### DIFF
--- a/ansible/roles/dev_tools/tasks/commands/rust.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/rust.yaml
@@ -1,0 +1,9 @@
+# rust toolchain
+- name: setup rust toolchain
+  become: false
+  block:
+    - name: install rustup and rust toolchain
+      ansible.builtin.shell: >-
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      args:
+        creates: "{{ lookup('env','HOME') }}/.cargo/bin/rustc"

--- a/ansible/roles/dev_tools/tasks/main.yaml
+++ b/ansible/roles/dev_tools/tasks/main.yaml
@@ -34,3 +34,5 @@
 - import_tasks: commands/pipx.yaml
 
 - import_tasks: commands/devcontainer.yaml
+
+- import_tasks: commands/rust.yaml


### PR DESCRIPTION
## Summary
- Add `ansible/roles/dev_tools/tasks/commands/rust.yaml` to install the Rust toolchain via `rustup.rs` (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`)
- Import the new task from `dev_tools/tasks/main.yaml`

## Test plan
- [ ] Run the `dev_tools` role and confirm `rustc`/`cargo` are installed under `~/.cargo/bin`
- [ ] Re-run the role and confirm the install task is skipped (idempotent via `creates`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)