### PR TITLE
refactor(ansible): skip install tasks if the command already exists

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,7 +1,14 @@
 - hosts: localhost
   become: true
+  vars:
+    # directories where the commands installed by this playbook are placed
+    extra_paths:
+      - "{{ lookup('env','HOME') }}/.local/bin"
+      - "{{ lookup('env','HOME') }}/.cargo/bin"
+      - "{{ lookup('env','HOME') }}/.bun/bin"
+      - "{{ lookup('env','HOME') }}/.devcontainers/bin"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ lookup('env','HOME') }}/.local/bin"
+    PATH: "{{ ansible_env.PATH }}:{{ extra_paths | join(':') }}"
   roles:
     - role: init_snap
     - role: xdg_base_directory

--- a/ansible/roles/dev_tools/tasks/commands/act.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/act.yaml
@@ -1,6 +1,13 @@
 # act
+- name: check act command
+  ansible.builtin.command: which act
+  register: which_act
+  failed_when: false
+  changed_when: false
+
 - name: setup act command
   become: false
+  when: which_act.rc != 0
   block:
     - name: download act
       ansible.builtin.get_url:
@@ -17,3 +24,7 @@
         src: /tmp/act
         dest: "{{ lookup('env','HOME') }}/.local/bin/act"
         mode: "0755"
+
+- name: verify act command
+  ansible.builtin.command: which act
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/bat.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/bat.yaml
@@ -14,11 +14,12 @@
       changed_when: false
 
     - name: symlink batcat to bat
+      become: false
       file:
         src: "{{ which_batcat.stdout }}"
         dest: "{{ lookup('env','HOME') }}/.local/bin/bat"
         state: link
 
-    - name: check bat command
+    - name: verify bat command
       ansible.builtin.command: which bat
       changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/bun.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/bun.yaml
@@ -1,9 +1,20 @@
 # bun (provides bunx)
+- name: check bun command
+  ansible.builtin.command: which bun
+  register: which_bun
+  failed_when: false
+  changed_when: false
+
 - name: setup bun
   become: false
+  when: which_bun.rc != 0
   block:
     - name: install bun
       ansible.builtin.shell: >-
         curl -fsSL https://bun.com/install | bash
       args:
         creates: "{{ lookup('env','HOME') }}/.bun/bin/bun"
+
+- name: verify bunx command
+  ansible.builtin.command: which bunx
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/devcontainer.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/devcontainer.yaml
@@ -1,7 +1,18 @@
 # devcontainer
+- name: check devcontainer command
+  ansible.builtin.command: which devcontainer
+  register: which_devcontainer
+  failed_when: false
+  changed_when: false
+
 - name: setup devcontainer
   become: false
+  when: which_devcontainer.rc != 0
   block:
     - name: install
       ansible.builtin.shell: >-
         curl -fsSL https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh | sh
+
+- name: verify devcontainer command
+  ansible.builtin.command: which devcontainer
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/difft.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/difft.yaml
@@ -1,6 +1,13 @@
 # difft
+- name: check difft command
+  ansible.builtin.command: which difft
+  register: which_difft
+  failed_when: false
+  changed_when: false
+
 - name: setup difft command
   become: false
+  when: which_difft.rc != 0
   block:
     - name: download difftastic
       ansible.builtin.get_url:
@@ -13,5 +20,6 @@
         # NOTE: only contains "difft" file
         dest: "{{ lookup('env','HOME') }}/.local/bin/"
 
-    - name: check difft
-      ansible.builtin.command: which difft
+- name: verify difft command
+  ansible.builtin.command: which difft
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/fd.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/fd.yaml
@@ -20,6 +20,6 @@
         dest: "{{ lookup('env','HOME') }}/.local/bin/fd"
         state: link
 
-    - name: check fd command
+    - name: verify fd command
       ansible.builtin.command: which fd
       changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/ghq.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/ghq.yaml
@@ -1,6 +1,13 @@
 # ghq
+- name: check ghq command
+  ansible.builtin.command: which ghq
+  register: which_ghq
+  failed_when: false
+  changed_when: false
+
 - name: setup ghq command
   become: false
+  when: which_ghq.rc != 0
   block:
     - name: download binary
       ansible.builtin.get_url:
@@ -23,3 +30,7 @@
         src: /tmp/ghq_linux_amd64/misc/bash/_ghq
         dest: "{{ lookup('env','HOME') }}/.local/share/bash-completion/completions/ghq"
         mode: "0644"
+
+- name: verify ghq command
+  ansible.builtin.command: which ghq
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/lsd.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/lsd.yaml
@@ -6,6 +6,10 @@
   changed_when: false
 
 - name: install lsd command
+  when: which_lsd.rc != 0
   apt:
     deb: https://github.com/lsd-rs/lsd/releases/download/v1.2.0/lsd-musl_1.2.0_amd64.deb
-  when: which_lsd.rc != 0
+
+- name: verify lsd command
+  ansible.builtin.command: which lsd
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/nvidia-container.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/nvidia-container.yaml
@@ -1,13 +1,21 @@
+# nvidia-container
 - name: setup nvidia-container
   when: not is_ci
   block:
-    - name: check nvidia-smi
-      shell: command -v nvidia-smi >/dev/null 2>&1
-      register: nvidia_smi_exists
+    - name: check nvidia-smi command
+      ansible.builtin.command: which nvidia-smi
+      register: which_nvidia_smi
       failed_when: false
+      changed_when: false
+
+    - name: check nvidia-ctk command
+      ansible.builtin.command: which nvidia-ctk
+      register: which_nvidia_ctk
+      failed_when: false
+      changed_when: false
 
     - name: install nvidia-container
-      when: nvidia_smi_exists.rc == 0
+      when: which_nvidia_smi.rc == 0 and which_nvidia_ctk.rc != 0
       block:
         - name: add gpg key
           shell:
@@ -28,3 +36,8 @@
 
         - name: configure
           shell: nvidia-ctk runtime configure --runtime=docker && systemctl restart docker
+
+    - name: verify nvidia-ctk command
+      when: which_nvidia_smi.rc == 0
+      ansible.builtin.command: which nvidia-ctk
+      changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/pipx.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/pipx.yaml
@@ -1,7 +1,14 @@
 # pipx
 # from https://pipx.pypa.io/stable/how-to/install-pipx.html
+- name: check pipx command
+  ansible.builtin.command: which pipx
+  register: which_pipx
+  failed_when: false
+  changed_when: false
+
 - name: setup pipx command
   become: false
+  when: which_pipx.rc != 0
   block:
     - name: create pipx venv
       ansible.builtin.command: python3 -m venv {{ lookup('env','HOME') }}/.local/share/pipx-venv
@@ -22,6 +29,6 @@
     - name: pipx ensurepath
       ansible.builtin.command: "{{ lookup('env','HOME') }}/.local/bin/pipx ensurepath"
 
-    - name: check pipx command
-      ansible.builtin.command: which pipx
-      changed_when: false
+- name: verify pipx command
+  ansible.builtin.command: which pipx
+  changed_when: false

--- a/ansible/roles/dev_tools/tasks/commands/rust.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/rust.yaml
@@ -1,9 +1,20 @@
 # rust toolchain
+- name: check rustc command
+  ansible.builtin.command: which rustc
+  register: which_rustc
+  failed_when: false
+  changed_when: false
+
 - name: setup rust toolchain
   become: false
+  when: which_rustc.rc != 0
   block:
     - name: install rustup and rust toolchain
       ansible.builtin.shell: >-
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       args:
         creates: "{{ lookup('env','HOME') }}/.cargo/bin/rustc"
+
+- name: verify rustc command
+  ansible.builtin.command: which rustc
+  changed_when: false

--- a/ansible/roles/fonts/tasks/main.yaml
+++ b/ansible/roles/fonts/tasks/main.yaml
@@ -21,21 +21,37 @@
 
 - name: install Moralerspace font
   when: not is_ci # this font file is large
+  vars:
+    moralerspace_version: v2.0.0
+    moralerspace_dir: "/usr/local/share/fonts/MoralerspaceHW_{{ moralerspace_version }}"
   block:
-    - name: download Moralerspace zip file
-      ansible.builtin.get_url:
-        url: https://github.com/yuru7/moralerspace/releases/download/v2.0.0/MoralerspaceHW_v2.0.0.zip
-        dest: /tmp/MoralerspaceHW.zip
+    - name: check Moralerspace font is installed
+      ansible.builtin.stat:
+        path: "{{ moralerspace_dir }}/MoralerspaceNeonHW-Regular.ttf"
+      register: moralerspace_installed
+      changed_when: false
 
-    - name: unarchive Moralerspace zip file
-      ansible.builtin.unarchive:
-        src: /tmp/MoralerspaceHW.zip
-        dest: /usr/local/share/fonts/
-        include:
-          - MoralerspaceHW_v2.0.0/MoralerspaceNeonHW-Regular.ttf
-          - MoralerspaceHW_v2.0.0/MoralerspaceNeonHW-Bold.ttf
-          - MoralerspaceHW_v2.0.0/MoralerspaceNeonHW-Italic.ttf
-          - MoralerspaceHW_v2.0.0/MoralerspaceNeonHW-BoldItalic.ttf
+    - name: install Moralerspace font
+      when: not moralerspace_installed.stat.exists
+      block:
+        - name: download Moralerspace zip file
+          ansible.builtin.get_url:
+            url: https://github.com/yuru7/moralerspace/releases/download/{{ moralerspace_version }}/MoralerspaceHW_{{ moralerspace_version }}.zip
+            dest: /tmp/MoralerspaceHW.zip
 
-    - name: update cache after Moralerspace
-      ansible.builtin.shell: fc-cache -vf
+        - name: unarchive Moralerspace zip file
+          ansible.builtin.unarchive:
+            src: /tmp/MoralerspaceHW.zip
+            dest: /usr/local/share/fonts/
+            include:
+              - MoralerspaceHW_{{ moralerspace_version }}/MoralerspaceNeonHW-Regular.ttf
+              - MoralerspaceHW_{{ moralerspace_version }}/MoralerspaceNeonHW-Bold.ttf
+              - MoralerspaceHW_{{ moralerspace_version }}/MoralerspaceNeonHW-Italic.ttf
+              - MoralerspaceHW_{{ moralerspace_version }}/MoralerspaceNeonHW-BoldItalic.ttf
+
+        - name: update cache after Moralerspace
+          ansible.builtin.shell: fc-cache -vf
+
+    - name: verify Moralerspace font is available
+      ansible.builtin.shell: fc-list | grep -q "Moralerspace Neon HW"
+      changed_when: false

--- a/ansible/roles/fonts/tasks/main.yaml
+++ b/ansible/roles/fonts/tasks/main.yaml
@@ -17,7 +17,7 @@
       - fonts-takao-pgothic
       - fonts-firacode
     state: present
-    check_mode: true
+  check_mode: true
 
 - name: install Moralerspace font
   when: not is_ci # this font file is large

--- a/ansible/roles/fonts/tasks/main.yaml
+++ b/ansible/roles/fonts/tasks/main.yaml
@@ -17,7 +17,7 @@
       - fonts-takao-pgothic
       - fonts-firacode
     state: present
-  check_mode: true
+    check_mode: true
 
 - name: install Moralerspace font
   when: not is_ci # this font file is large

--- a/ansible/roles/gui_tools/tasks/main.yaml
+++ b/ansible/roles/gui_tools/tasks/main.yaml
@@ -17,4 +17,4 @@
       - gparted
       - flameshot
     state: present
-    check_mode: true
+  check_mode: true

--- a/ansible/roles/gui_tools/tasks/main.yaml
+++ b/ansible/roles/gui_tools/tasks/main.yaml
@@ -17,4 +17,4 @@
       - gparted
       - flameshot
     state: present
-  check_mode: true
+    check_mode: true

--- a/ansible/roles/init_snap/tasks/main.yaml
+++ b/ansible/roles/init_snap/tasks/main.yaml
@@ -6,3 +6,4 @@
 - name: refresh apt
   command: apt-get update
   become: true
+  changed_when: false

--- a/ansible/roles/system_tools/tasks/commands/btm.yaml
+++ b/ansible/roles/system_tools/tasks/commands/btm.yaml
@@ -1,4 +1,16 @@
+# btm
+- name: check btm command
+  ansible.builtin.command: which btm
+  register: which_btm
+  failed_when: false
+  changed_when: false
+
 - name: setup btm command
+  when: which_btm.rc != 0
   apt:
     deb: https://github.com/ClementTsang/bottom/releases/download/0.12.3/bottom-musl_0.12.3-1_amd64.deb
     state: present
+
+- name: verify btm command
+  ansible.builtin.command: which btm
+  changed_when: false

--- a/ansible/roles/system_tools/tasks/commands/tmux.yaml
+++ b/ansible/roles/system_tools/tasks/commands/tmux.yaml
@@ -76,12 +76,11 @@
       failed_when: false
       changed_when: false
 
-    # NOTE: build as the login user so that the artifacts under ~/.local are not owned by root
     - name: install tmux-mem-cpu-load
       become: false
       when: which_tmux_mem_cpu_load.rc != 0
       vars:
-        tmux_mem_cpu_load_src: "{{ lookup('env','HOME') }}/.cache/tmux-mem-cpu-load"
+        tmux_mem_cpu_load_src: "{{ lookup('env','HOME') }}/.local/build/tmux-mem-cpu-load"
       block:
         - name: clone project
           git:

--- a/ansible/roles/system_tools/tasks/commands/tmux.yaml
+++ b/ansible/roles/system_tools/tasks/commands/tmux.yaml
@@ -70,29 +70,44 @@
         - name: tmux-named-snapshot
           repo: https://github.com/spywhere/tmux-named-snapshot.git
 
+    - name: check tmux-mem-cpu-load command
+      ansible.builtin.command: which tmux-mem-cpu-load
+      register: which_tmux_mem_cpu_load
+      failed_when: false
+      changed_when: false
+
+    # NOTE: build as the login user so that the artifacts under ~/.local are not owned by root
     - name: install tmux-mem-cpu-load
+      become: false
+      when: which_tmux_mem_cpu_load.rc != 0
+      vars:
+        tmux_mem_cpu_load_src: "{{ lookup('env','HOME') }}/.cache/tmux-mem-cpu-load"
       block:
         - name: clone project
           git:
             repo: https://github.com/thewtex/tmux-mem-cpu-load.git
-            dest: /tmp/tmux-mem-cpu-load
+            dest: "{{ tmux_mem_cpu_load_src }}"
 
         - name: create build dir
           ansible.builtin.file:
-            path: /tmp/tmux-mem-cpu-load/build
+            path: "{{ tmux_mem_cpu_load_src }}/build"
             state: directory
 
         - name: cmake
           ansible.builtin.command:
             cmd: "cmake .. -DCMAKE_INSTALL_PREFIX={{ lookup('env','HOME') }}/.local"
-            chdir: /tmp/tmux-mem-cpu-load/build
+            chdir: "{{ tmux_mem_cpu_load_src }}/build"
 
         - name: build
           ansible.builtin.command:
             cmd: make -j
-            chdir: /tmp/tmux-mem-cpu-load/build
+            chdir: "{{ tmux_mem_cpu_load_src }}/build"
 
         - name: install
           ansible.builtin.command:
             cmd: make install
-            chdir: /tmp/tmux-mem-cpu-load/build
+            chdir: "{{ tmux_mem_cpu_load_src }}/build"
+
+    - name: verify tmux-mem-cpu-load command
+      ansible.builtin.command: which tmux-mem-cpu-load
+      changed_when: false

--- a/ansible/roles/terminal/tasks/commands/wezterm.yaml
+++ b/ansible/roles/terminal/tasks/commands/wezterm.yaml
@@ -1,7 +1,18 @@
 # wezterm
+- name: check wezterm command
+  ansible.builtin.command: which wezterm
+  register: which_wezterm
+  failed_when: false
+  changed_when: false
+
 - name: setup wezterm
+  when: which_wezterm.rc != 0
   block:
     - name: dpkg install wezterm
       apt:
         deb: https://github.com/wezterm/wezterm/releases/download/20240203-110809-5046fc22/wezterm-20240203-110809-5046fc22.Ubuntu22.04.deb
         state: present
+
+- name: verify wezterm command
+  ansible.builtin.command: which wezterm
+  changed_when: false


### PR DESCRIPTION
## Summary

apt 以外の手段でコマンドを install している task について、冪等化と PATH 確認のスタイルを統一しました。

```yaml
- name: check <cmd> command      # 既にあれば
  ansible.builtin.command: which <cmd>
  register: which_<cmd>
  failed_when: false
  changed_when: false

- name: setup <cmd> command      # install 本体を skip
  when: which_<cmd>.rc != 0
  block: ...

- name: verify <cmd> command     # install 後に PATH 上にあるか確認
  ansible.builtin.command: which <cmd>
  changed_when: false
```

適用先: `act` / `difft` / `ghq` / `bun` (verify は `bunx`) / `devcontainer` / `rust` (rustc) / `pipx` / `lsd` / `btm` / `wezterm` / `tmux-mem-cpu-load` / `nvidia-container` (nvidia-ctk)

これで解消される不要な changed:

- `difft` の `which difft` に `changed_when` が無く毎回 changed だった（`nvidia-smi` のチェックも同様）
- `devcontainer` は冪等化が無く毎回インストールスクリプトを実行していた
- `pipx ensurepath`、`btm` / `wezterm` の .deb ダウンロード、`act` / `ghq` / `difft` の tarball ダウンロード・展開
- `tmux-mem-cpu-load` の git clone + cmake/make/make install
- nvidia-container の `nvidia-ctk runtime configure && systemctl restart docker`（毎回 docker が再起動されていた）

## その他の修正

- `playbook.yaml`: `which` が全て解決できるよう、play の PATH を `extra_paths` 変数に切り出し、`~/.local/bin` に加えて `~/.cargo/bin` / `~/.bun/bin` / `~/.devcontainers/bin` を追加
- `tmux-mem-cpu-load` のビルドに `become: false` を追加（成果物が root 所有になっていた）。併せてビルド先を `/tmp` から `~/.cache` に変更
- `bat.yaml` の symlink task にも `become: false` を追加（`~/.local/bin/bat` が root 所有の symlink になっていた。`fd.yaml` には元から付いている）

## Test plan

- `uv run ansible-playbook --syntax-check playbook.yaml` 通過
- 追加した PATH 下で、対象 14 コマンドすべてが `which` で解決することを確認（= ローカル再実行時に install ブロックが全て skip される）
- 新規インストール経路は ansible-ci に任せています

## Note

- base は #133 (`feat/refactor-flag`) です。#133 の merge 後に main へ rebase してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmxTzTdtD11Yx8AGsupqzC