### PR TITLE
feat(tmux): show ETA until usage limit in ccusage status line

### DIFF
--- a/.config/tmux/scripts/ccusage_monitor.sh
+++ b/.config/tmux/scripts/ccusage_monitor.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 claude_icon='󱙺'
-token_icon=''
+token_icon=''
 timer_icon='󰔟'
+limit_icon='󰄼'
 
 ccusage_cmd() {
 	if command -v bunx >/dev/null 2>&1; then
@@ -14,15 +15,24 @@ ccusage_cmd() {
 
 monitor_ccusage() {
 	local json
-	json=$(ccusage_cmd blocks --offline --active --json 2>/dev/null)
+	json=$(ccusage_cmd blocks --offline --json 2>/dev/null)
 	if [[ $? -ne 0 || -z "$json" ]]; then
 		echo "Claude $claude_icon / no ccusage "
 		return
 	fi
 	# // cSpell:disable
-	echo "$json" | jq -r --arg c "$claude_icon" --arg t "$token_icon" --arg r "$timer_icon" '
-		.blocks[0] // empty
-		| "Claude \($c) / \($t) \((.totalTokens / 1000) | round)k / \($r) \(.projection.remainingMinutes // 0)m / \(((.burnRate.tokensPerMinute // 0) / 1000) | round)k/min"
+	echo "$json" | jq -r --arg c "$claude_icon" --arg t "$token_icon" --arg r "$timer_icon" --arg l "$limit_icon" '
+		[.blocks[] | select(.isGap | not)] as $blocks
+		| ($blocks | map(select(.isActive | not) | .costUSD) | max // 0) as $limit
+		| ($blocks[] | select(.isActive)) // empty
+		| (.burnRate.costPerHour // 0) as $rate
+		| (.burnRate.tokensPerMinute // 0) as $token_rate
+		| (.projection.remainingMinutes // 0) as $remaining
+		| (if $limit <= 0 or $rate <= 0 then $remaining
+			elif .costUSD >= $limit then 0
+			else (($limit - .costUSD) / $rate * 60) | floor end) as $eta_min
+		| (if $eta_min > $remaining then ">\($remaining)min" else "\($eta_min)min" end) as $eta_text
+		| "Claude \($c) / \($t) \((.totalTokens / 1000) | round)k / \($r) \($remaining)min(\($l) \($eta_text)) / \((($token_rate) / 1000) | round)k/min"
 	' | grep . || echo "Claude $claude_icon / idle "
 	# // cSpell:enable
 }


### PR DESCRIPTION
Show, in the tmux ccusage status line, how many minutes until the usage limit is reached at the current pace.

- The limit is not exposed in the ccusage JSON, so it is estimated as the max `costUSD` among past (non-gap, non-active) blocks — the same idea as `ccusage blocks --token-limit max`.
- ETA = `(limit - costUSD) / burnRate.costPerHour * 60`, shown next to the block reset time.
- Fetches all blocks rather than `--active` only; measured at ~0.06s, so no noticeable delay.

Display stays token-based; only the ETA uses cost.

```
Claude 󱙺 /  2701k / 󰔟 278min(󰄼 94min) / 137k/min
```

Edge cases:
- burn rate 0 (idle) or no past blocks → ETA falls back to the remaining block time
- already over the estimated limit → `0min`
- limit reached after the block resets → `>NNNmin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SszNzsMvJ9ZH15c1dYXydo