### PR TITLE
chore(renovate): ignore patch updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,12 @@
   ],
   packageRules: [
     {
+      // patch updates are not worth a PR for these tools. minor and major are
+      // still opened
+      matchUpdateTypes: ["patch"],
+      enabled: false,
+    },
+    {
       matchManagers: ["custom.regex"],
       semanticCommitScope: "ansible",
       commitMessageTopic: "{{depName}}",


### PR DESCRIPTION
`matchUpdateTypes: ["patch"]` を `enabled: false` にして、patch levelの更新ではPRを作らないようにする。minorとmajorはこれまで通り作られる。

`getUpdateType()` はmajor/minor/patchを `separateMinorPatch` とは独立に判定するため、この rule は全 manager (github-actions と custom.regex) に対して効く。

参考: 現在openしているPRのupdateTypeは difftastic/bottom/ghq が minor、act (v0.2.84 -> v0.2.89) が patch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aVdWSLTWB8VmHUBKgBVcN