### PR TITLE
fix(ansible): download the archive of the pinned version

### DIFF
--- a/ansible/roles/dev_tools/tasks/commands/act.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/act.yaml
@@ -22,11 +22,13 @@
     - name: download act
       ansible.builtin.get_url:
         url: https://github.com/nektos/act/releases/download/{{ act_version }}/act_Linux_x86_64.tar.gz
-        dest: /tmp/act.tar.gz
+        # NOTE: the version is in the file name because get_url does not
+        # re-download when dest already exists
+        dest: /tmp/act-{{ act_version }}.tar.gz
 
     - name: unarchive act
       ansible.builtin.unarchive:
-        src: /tmp/act.tar.gz
+        src: /tmp/act-{{ act_version }}.tar.gz
         dest: /tmp
 
     - name: install act

--- a/ansible/roles/dev_tools/tasks/commands/difft.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/difft.yaml
@@ -22,11 +22,13 @@
     - name: download difftastic
       ansible.builtin.get_url:
         url: https://github.com/Wilfred/difftastic/releases/download/{{ difft_version }}/difft-x86_64-unknown-linux-gnu.tar.gz
-        dest: /tmp/difftastic.tar.gz
+        # NOTE: the version is in the file name because get_url does not
+        # re-download when dest already exists
+        dest: /tmp/difftastic-{{ difft_version }}.tar.gz
 
     - name: install difftastic
       ansible.builtin.unarchive:
-        src: /tmp/difftastic.tar.gz
+        src: /tmp/difftastic-{{ difft_version }}.tar.gz
         # NOTE: only contains "difft" file
         dest: "{{ lookup('env','HOME') }}/.local/bin/"
 

--- a/ansible/roles/dev_tools/tasks/commands/ghq.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/ghq.yaml
@@ -23,11 +23,13 @@
     - name: download binary
       ansible.builtin.get_url:
         url: https://github.com/x-motemen/ghq/releases/download/{{ ghq_version }}/ghq_linux_amd64.zip
-        dest: /tmp/ghq_linux_amd64.zip
+        # NOTE: the version is in the file name because get_url does not
+        # re-download when dest already exists
+        dest: /tmp/ghq-{{ ghq_version }}.zip
 
     - name: unarchive ghq
       ansible.builtin.unarchive:
-        src: /tmp/ghq_linux_amd64.zip
+        src: /tmp/ghq-{{ ghq_version }}.zip
         dest: /tmp/
 
     - name: install binary

--- a/ansible/roles/fonts/tasks/main.yaml
+++ b/ansible/roles/fonts/tasks/main.yaml
@@ -37,11 +37,13 @@
         - name: download Moralerspace zip file
           ansible.builtin.get_url:
             url: https://github.com/yuru7/moralerspace/releases/download/{{ moralerspace_version }}/MoralerspaceHW_{{ moralerspace_version }}.zip
-            dest: /tmp/MoralerspaceHW.zip
+            # NOTE: the version is in the file name because get_url does
+            # not re-download when dest already exists
+            dest: /tmp/MoralerspaceHW_{{ moralerspace_version }}.zip
 
         - name: unarchive Moralerspace zip file
           ansible.builtin.unarchive:
-            src: /tmp/MoralerspaceHW.zip
+            src: /tmp/MoralerspaceHW_{{ moralerspace_version }}.zip
             dest: /usr/local/share/fonts/
             include:
               - MoralerspaceHW_{{ moralerspace_version }}/MoralerspaceNeonHW-Regular.ttf


### PR DESCRIPTION
## 問題

Renovateが `ansible/vars/versions.yaml` のversionを上げた後にplaybookを実行しても、`difft` / `act` / `ghq` が古いversionのままだった。version stampだけが新しいversionに更新されるため、次回以降はinstall block自体がskipされ、永久に古いままになる。

```
stamp: difft=0.70.0  act=v0.2.89  ghq=v1.10.1
実体:  difft 0.67.0   act 0.2.84   ghq 1.8.0
```

## 原因

`ansible.builtin.get_url` はdefaultが `force: false` で、**dest が既に存在する場合はdownloadをskipする**(同じdestに対するlast-modified比較のみで、URLが変わったかどうかは見ない)。destが `/tmp/difftastic.tar.gz` のようにversionに依存しない固定名だったため、前回のrunで落とした古いarchiveがそのまま再展開されていた。

`apt` moduleの `deb:` でinstallしているlsd / btm / wezterm は、moduleが毎回自分で一時fileにdownloadするのでこの問題は起きない。影響を受けるのは `get_url` を使う difft / act / ghq とMoralerspace fontの4箇所。

## 修正

destのfile名にversionを含めて、別versionは別fileになるようにした。

## 確認

手元で古いarchiveを `/tmp` に残したまま実行し、修正後は正しく更新されることを確認した。

```
Difftastic 0.70.0
act version 0.2.89
ghq version 1.10.1
```

2回目の実行は `changed=0 skipped=3` で冪等。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aVdWSLTWB8VmHUBKgBVcN