### PR TITLE
refactor(ansible): compare the version of the installed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ uv run ansible-playbook ansible/playbook.yaml --ask-become-pass
 
 `RENOVATE_TOKEN` secretにPAT(`repo`と`workflow` scope)が必要．
 
-ansibleはinstall済みのversionをローカルの`~/.local/share/dotfiles/versions/`に記録しており，`ansible/vars/versions.yaml`と一致しない場合は再installする．
+ansibleは各commandの`--version`の出力と`ansible/vars/versions.yaml`を比較し，一致しない場合に再installする．
 
 ## 日本語入力
 

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -3,9 +3,6 @@
   vars_files:
     - vars/versions.yaml
   vars:
-    # records the version of each tool installed from a GitHub release, so that
-    # the playbook can detect an outdated installation and re-install it
-    version_stamp_dir: "{{ lookup('env','HOME') }}/.local/share/dotfiles/versions"
     # directories where the commands installed by this playbook are placed
     extra_paths:
       - "{{ lookup('env','HOME') }}/.local/bin"

--- a/ansible/roles/dev_tools/tasks/commands/act.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/act.yaml
@@ -1,14 +1,8 @@
 # act
-- name: check act command
-  ansible.builtin.command: which act
-  register: which_act
-  failed_when: false
-  changed_when: false
-
-- name: read act version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/act"
-  register: act_stamp
+- name: check act version
+  # NOTE: the output is like "act version 0.2.89"
+  ansible.builtin.command: act --version
+  register: act_current
   failed_when: false
   changed_when: false
 
@@ -16,8 +10,9 @@
   become: false
   vars:
     act_version: "{{ versions.act.version }}"
-    act_installed: "{{ (act_stamp.content | b64decode | trim) if act_stamp.content is defined else '' }}"
-  when: which_act.rc != 0 or act_installed != act_version
+    act_installed: "{{ act_current.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+  # install if missing, or if the installed version is not the pinned one
+  when: act_installed != (act_version | regex_replace('^v', ''))
   block:
     - name: download act
       ansible.builtin.get_url:
@@ -37,12 +32,8 @@
         dest: "{{ lookup('env','HOME') }}/.local/bin/act"
         mode: "0755"
 
-    - name: stamp act version
-      copy:
-        content: "{{ act_version }}"
-        dest: "{{ version_stamp_dir }}/act"
-        mode: "0644"
-
-- name: verify act command
-  ansible.builtin.command: which act
+- name: verify act version
+  ansible.builtin.command: act --version
+  register: act_verified
   changed_when: false
+  failed_when: (act_verified.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) != (versions.act.version | regex_replace('^v', ''))

--- a/ansible/roles/dev_tools/tasks/commands/difft.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/difft.yaml
@@ -1,14 +1,8 @@
 # difft
-- name: check difft command
-  ansible.builtin.command: which difft
-  register: which_difft
-  failed_when: false
-  changed_when: false
-
-- name: read difft version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/difft"
-  register: difft_stamp
+- name: check difft version
+  # NOTE: the 1st line is like "Difftastic 0.70.0"
+  ansible.builtin.command: difft --version
+  register: difft_current
   failed_when: false
   changed_when: false
 
@@ -16,8 +10,9 @@
   become: false
   vars:
     difft_version: "{{ versions.difftastic.version }}"
-    difft_installed: "{{ (difft_stamp.content | b64decode | trim) if difft_stamp.content is defined else '' }}"
-  when: which_difft.rc != 0 or difft_installed != difft_version
+    difft_installed: "{{ difft_current.stdout_lines[0] | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+  # install if missing, or if the installed version is not the pinned one
+  when: difft_installed != (difft_version | regex_replace('^v', ''))
   block:
     - name: download difftastic
       ansible.builtin.get_url:
@@ -32,12 +27,8 @@
         # NOTE: only contains "difft" file
         dest: "{{ lookup('env','HOME') }}/.local/bin/"
 
-    - name: stamp difft version
-      copy:
-        content: "{{ difft_version }}"
-        dest: "{{ version_stamp_dir }}/difft"
-        mode: "0644"
-
-- name: verify difft command
-  ansible.builtin.command: which difft
+- name: verify difft version
+  ansible.builtin.command: difft --version
+  register: difft_verified
   changed_when: false
+  failed_when: (difft_verified.stdout_lines[0] | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) != (versions.difftastic.version | regex_replace('^v', ''))

--- a/ansible/roles/dev_tools/tasks/commands/ghq.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/ghq.yaml
@@ -1,14 +1,8 @@
 # ghq
-- name: check ghq command
-  ansible.builtin.command: which ghq
-  register: which_ghq
-  failed_when: false
-  changed_when: false
-
-- name: read ghq version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/ghq"
-  register: ghq_stamp
+- name: check ghq version
+  # NOTE: the output is like "ghq version 1.10.1 (rev:f600896)"
+  ansible.builtin.command: ghq --version
+  register: ghq_current
   failed_when: false
   changed_when: false
 
@@ -16,9 +10,9 @@
   become: false
   vars:
     ghq_version: "{{ versions.ghq.version }}"
-    ghq_installed: "{{ (ghq_stamp.content | b64decode | trim) if ghq_stamp.content is defined else '' }}"
+    ghq_installed: "{{ ghq_current.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
   # install if missing, or if the installed version is not the pinned one
-  when: which_ghq.rc != 0 or ghq_installed != ghq_version
+  when: ghq_installed != (ghq_version | regex_replace('^v', ''))
   block:
     - name: download binary
       ansible.builtin.get_url:
@@ -44,12 +38,8 @@
         dest: "{{ lookup('env','HOME') }}/.local/share/bash-completion/completions/ghq"
         mode: "0644"
 
-    - name: stamp ghq version
-      copy:
-        content: "{{ ghq_version }}"
-        dest: "{{ version_stamp_dir }}/ghq"
-        mode: "0644"
-
-- name: verify ghq command
-  ansible.builtin.command: which ghq
+- name: verify ghq version
+  ansible.builtin.command: ghq --version
+  register: ghq_verified
   changed_when: false
+  failed_when: (ghq_verified.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) != (versions.ghq.version | regex_replace('^v', ''))

--- a/ansible/roles/dev_tools/tasks/commands/lsd.yaml
+++ b/ansible/roles/dev_tools/tasks/commands/lsd.yaml
@@ -1,34 +1,24 @@
 # lsd
-- name: check lsd command
-  ansible.builtin.command: which lsd
-  register: which_lsd
-  failed_when: false
-  changed_when: false
-
-- name: read lsd version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/lsd"
-  register: lsd_stamp
+- name: check lsd version
+  # NOTE: the output is like "lsd 1.2.0"
+  ansible.builtin.command: lsd --version
+  register: lsd_current
   failed_when: false
   changed_when: false
 
 - name: setup lsd command
   vars:
     lsd_version: "{{ versions.lsd.version }}"
-    lsd_installed: "{{ (lsd_stamp.content | b64decode | trim) if lsd_stamp.content is defined else '' }}"
-  when: which_lsd.rc != 0 or lsd_installed != lsd_version
+    lsd_installed: "{{ lsd_current.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+  # install if missing, or if the installed version is not the pinned one
+  when: lsd_installed != (lsd_version | regex_replace('^v', ''))
   block:
     - name: dpkg install lsd
       apt:
         deb: https://github.com/lsd-rs/lsd/releases/download/{{ lsd_version }}/lsd-musl_{{ lsd_version | regex_replace('^v', '') }}_amd64.deb
 
-    - name: stamp lsd version
-      become: false
-      copy:
-        content: "{{ lsd_version }}"
-        dest: "{{ version_stamp_dir }}/lsd"
-        mode: "0644"
-
-- name: verify lsd command
-  ansible.builtin.command: which lsd
+- name: verify lsd version
+  ansible.builtin.command: lsd --version
+  register: lsd_verified
   changed_when: false
+  failed_when: (lsd_verified.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) != (versions.lsd.version | regex_replace('^v', ''))

--- a/ansible/roles/system_tools/tasks/commands/btm.yaml
+++ b/ansible/roles/system_tools/tasks/commands/btm.yaml
@@ -1,22 +1,17 @@
 # btm
-- name: check btm command
-  ansible.builtin.command: which btm
-  register: which_btm
-  failed_when: false
-  changed_when: false
-
-- name: read btm version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/btm"
-  register: btm_stamp
+- name: check btm version
+  # NOTE: the output is like "bottom 0.14.8"
+  ansible.builtin.command: btm --version
+  register: btm_current
   failed_when: false
   changed_when: false
 
 - name: setup btm command
   vars:
     btm_version: "{{ versions.bottom.version }}"
-    btm_installed: "{{ (btm_stamp.content | b64decode | trim) if btm_stamp.content is defined else '' }}"
-  when: which_btm.rc != 0 or btm_installed != btm_version
+    btm_installed: "{{ btm_current.stdout | default('') | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') }}"
+  # install if missing, or if the installed version is not the pinned one
+  when: btm_installed != btm_version
   block:
     - name: dpkg install btm
       apt:
@@ -24,13 +19,8 @@
         deb: https://github.com/ClementTsang/bottom/releases/download/{{ btm_version }}/bottom-musl_{{ btm_version }}-1_amd64.deb
         state: present
 
-    - name: stamp btm version
-      become: false
-      copy:
-        content: "{{ btm_version }}"
-        dest: "{{ version_stamp_dir }}/btm"
-        mode: "0644"
-
-- name: verify btm command
-  ansible.builtin.command: which btm
+- name: verify btm version
+  ansible.builtin.command: btm --version
+  register: btm_verified
   changed_when: false
+  failed_when: (btm_verified.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+')) != versions.bottom.version

--- a/ansible/roles/terminal/tasks/commands/wezterm.yaml
+++ b/ansible/roles/terminal/tasks/commands/wezterm.yaml
@@ -1,35 +1,26 @@
 # wezterm
-- name: check wezterm command
-  ansible.builtin.command: which wezterm
-  register: which_wezterm
-  failed_when: false
-  changed_when: false
-
-- name: read wezterm version stamp
-  ansible.builtin.slurp:
-    path: "{{ version_stamp_dir }}/wezterm"
-  register: wezterm_stamp
+- name: check wezterm version
+  # NOTE: the output is like "wezterm 20240203-110809-5046fc22"
+  ansible.builtin.command: wezterm --version
+  register: wezterm_current
   failed_when: false
   changed_when: false
 
 - name: setup wezterm
   vars:
     wezterm_version: "{{ versions.wezterm.version }}"
-    wezterm_installed: "{{ (wezterm_stamp.content | b64decode | trim) if wezterm_stamp.content is defined else '' }}"
-  when: which_wezterm.rc != 0 or wezterm_installed != wezterm_version
+    # NOTE: the version is not a semver, so take the last field instead
+    wezterm_installed: "{{ (wezterm_current.stdout_lines[0] | default('')).split() | last | default('') }}"
+  # install if missing, or if the installed version is not the pinned one
+  when: wezterm_installed != wezterm_version
   block:
     - name: dpkg install wezterm
       apt:
         deb: https://github.com/wezterm/wezterm/releases/download/{{ wezterm_version }}/wezterm-{{ wezterm_version }}.Ubuntu22.04.deb
         state: present
 
-    - name: stamp wezterm version
-      become: false
-      copy:
-        content: "{{ wezterm_version }}"
-        dest: "{{ version_stamp_dir }}/wezterm"
-        mode: "0644"
-
-- name: verify wezterm command
-  ansible.builtin.command: which wezterm
+- name: verify wezterm version
+  ansible.builtin.command: wezterm --version
+  register: wezterm_verified
   changed_when: false
+  failed_when: (wezterm_verified.stdout_lines[0].split() | last) != versions.wezterm.version

--- a/ansible/roles/xdg_base_directory/tasks/main.yaml
+++ b/ansible/roles/xdg_base_directory/tasks/main.yaml
@@ -12,13 +12,6 @@
     state: directory
     mode: '0755'
 
-- name: create version stamp dir
-  become: false
-  file:
-    path: "{{ version_stamp_dir }}"
-    state: directory
-    mode: '0755'
-
 - name: check PATH
   ansible.builtin.shell: echo $PATH
   register: out


### PR DESCRIPTION
## 変更

install済みcommandのversionをversion stamp fileで管理するのをやめ、command自身の `--version` の出力と `versions.yaml` を直接比較するようにした。stampはplaybookが「installしたと思っているversion」でしかなく、実際に置かれているものとdriftしうる(#151 がまさにそれ)。

| command | `--version` の出力 | pin | 取り出し方 |
| --- | --- | --- | --- |
| difft | `Difftastic 0.70.0` (複数行の1行目) | `0.70.0` | semverをregex_search |
| act | `act version 0.2.89` | `v0.2.89` | semverをregex_search |
| ghq | `ghq version 1.10.1 (rev:f600896)` | `v1.10.1` | semverをregex_search |
| lsd | `lsd 1.2.0` | `v1.2.0` | semverをregex_search |
| btm | `bottom 0.14.8` | `0.14.8` | semverをregex_search |
| wezterm | `wezterm 20240203-110809-5046fc22` | 同左 | semverではないので最終fieldを使う |

- ghqは末尾にrevが付くので単純な最終field取得では壊れる。difftは複数行なので1行目に限定する。
- `v` 付きでpinしているものだけ `regex_replace('^v', '')` してから比較する。
- commandが無い場合は `stdout` が空になり比較が一致しないのでinstallが走る。`which` によるcheckは不要になったので削除した。
- `verify` taskも `which` ではなくversionの一致をcheckする。**installしたのに版が合わない場合はその場でplaybookが失敗する**ので、#151 のような「静かに古いまま」が起きない。
- stamp機構を使うものが無くなったので、`version_stamp_dir` 変数と `xdg_base_directory` のstamp dir作成taskを削除した。READMEも更新。

## 確認

difftで3ケース:

```
1. 既に最新          -> changed=0, install blockがskip
2. 古いversionを指定 -> 0.70.0 から 0.67.0 へ入れ替わる
3. commandを消す     -> installが走り 0.70.0 が入る
```

lsd / btm / wezterm は一致時にskipされること、および不一致時にinstall blockへ入ることを確認(実際のinstallはdowngrade/存在しないtagなので想定通り失敗する)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aVdWSLTWB8VmHUBKgBVcN
