### PR TITLE
chore(renovate): group updates per manager and enable patch updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,12 +22,6 @@
   ],
   packageRules: [
     {
-      // patch updates are not worth a PR for these tools. minor and major are
-      // still opened
-      matchUpdateTypes: ["patch"],
-      enabled: false,
-    },
-    {
       matchManagers: ["custom.regex"],
       semanticCommitScope: "ansible",
       // open a single PR for all the tools installed by ansible

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,14 @@
     {
       matchManagers: ["custom.regex"],
       semanticCommitScope: "ansible",
+      // open a single PR for all the tools installed by ansible
+      groupName: "ansible tools",
       commitMessageTopic: "{{depName}}",
+    },
+    {
+      matchManagers: ["github-actions"],
+      // open a single PR for all the actions used in the workflows
+      groupName: "github actions",
     },
   ],
 }


### PR DESCRIPTION
## Summary
- ansible が管理するツール (`ansible/vars/versions.yaml`) の更新を `ansible tools` として1本のPRにまとめる
- workflow で使う actions の更新を `github actions` として1本のPRにまとめる
- patch 更新を無効化していたルールを削除（グループ化により PR 数が増えないため）

## Note
グループ化により PR タイトルは `chore(ansible): update ansible tools` のような形になり、`commitMessageTopic: "{{depName}}"` はグループ名で上書きされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVKcEBUkrFfZxLYhD3y4eF